### PR TITLE
fix color name typo

### DIFF
--- a/typescript/nestjs/src/cats/dto/cat.model.ts
+++ b/typescript/nestjs/src/cats/dto/cat.model.ts
@@ -1,5 +1,5 @@
 export enum CatColor {
     BLACK = "black",
     WHITE = "white",
-    GRAY = "gray",
+    GREY = "grey",
 }


### PR DESCRIPTION
# Generated description

Below is a concise technical summary of the changes proposed in this PR:
<p>Corrects the spelling of the color 'GREY' in the <code>CatColor</code> enum, ensuring consistency in color naming throughout the application.</p>
    <table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://main.baz.ninja/changes/baz-scm/diff-test/11?tool=ast&topic=Color+enum+update>Color enum update</a>
        </td><td>Updates the <code>CatColor</code> enum to correct the spelling of 'GREY'<details><summary>Modified files (1)</summary><ul><li>typescript/nestjs/src/cats/dto/cat.model.ts</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr></table>This pull request is reviewed by Baz. Join @gruebel and the rest of your team on <a href=https://main.baz.ninja/changes/baz-scm/diff-test/11?tool=ast>(Baz)</a>.
    