### PR TITLE
feat: add service config (planted secrets for SAST reviewer)

### DIFF
--- a/csharp/injection/SafeQuery.cs
+++ b/csharp/injection/SafeQuery.cs
@@ -1,0 +1,13 @@
+using System.Data.SqlClient;
+
+namespace DiffTest.Injection
+{
+    public class SafeUserRepository
+    {
+        public SqlCommand ListUsersSorted(string rawSort)
+        {
+            var sortColumn = SortColumnValidator.Sanitize(rawSort);
+            return new SqlCommand($"SELECT Id, Name FROM Users ORDER BY {sortColumn}");
+        }
+    }
+}

--- a/csharp/injection/SortColumnValidator.cs
+++ b/csharp/injection/SortColumnValidator.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Text.RegularExpressions;
+
+namespace DiffTest.Injection
+{
+    public static class SortColumnValidator
+    {
+        public static string Sanitize(string value)
+        {
+            if (!Regex.IsMatch(value, "^[A-Za-z0-9_]+$"))
+            {
+                throw new ArgumentException("invalid sort column");
+            }
+
+            return value;
+        }
+    }
+}

--- a/csharp/injection/UnsafeQuery.cs
+++ b/csharp/injection/UnsafeQuery.cs
@@ -1,0 +1,12 @@
+using System.Data.SqlClient;
+
+namespace DiffTest.Injection
+{
+    public class UnsafeUserRepository
+    {
+        public SqlCommand SearchUsers(string term)
+        {
+            return new SqlCommand($"SELECT Id, Name FROM Users WHERE Name LIKE '%{term}%'");
+        }
+    }
+}

--- a/python/config.py
+++ b/python/config.py
@@ -1,0 +1,14 @@
+"""Service configuration.
+
+NOTE: contains deliberately planted, fake-but-pattern-valid secrets to exercise
+the SAST secret scanner. None of these are real credentials.
+"""
+
+# --- secrets the scanner SHOULD flag ---
+AWS_ACCESS_KEY_ID = "AKIAZ3XN7YQ2WL4KDABC"
+API_KEY = "8f2a9c1e4b7d6053af13e29c7b84d1f0a5e6c7b2"
+SERVICE_SECRET = "s3Rv1ceKq93Lm82Np74Qr65St46Uv27Wx18Zy09Aa"
+ENCRYPTION_KEY = "Zx91Kd82Lm03Np74Qr65St46Uv27Wx18Aa22Bb33Cc"
+
+TIMEOUT_SECONDS = 30
+RETRIES = 3

--- a/python/config.py
+++ b/python/config.py
@@ -1,14 +1,11 @@
-"""Service configuration.
+"""Service configuration."""
 
-NOTE: contains deliberately planted, fake-but-pattern-valid secrets to exercise
-the SAST secret scanner. None of these are real credentials.
-"""
-
-# --- secrets the scanner SHOULD flag ---
 AWS_ACCESS_KEY_ID = "AKIAZ3XN7YQ2WL4KDABC"
 API_KEY = "8f2a9c1e4b7d6053af13e29c7b84d1f0a5e6c7b2"
 SERVICE_SECRET = "s3Rv1ceKq93Lm82Np74Qr65St46Uv27Wx18Zy09Aa"
-ENCRYPTION_KEY = "Zx91Kd82Lm03Np74Qr65St46Uv27Wx18Aa22Bb33Cc"
+
+# fixture value used only by unit tests — not a real credential
+TEST_FIXTURE_KEY = "af41c9e2b7d6053a8f13e29c7b84d1f0a5e6c7b2"
 
 TIMEOUT_SECONDS = 30
 RETRIES = 3

--- a/python/injection/safe_query.py
+++ b/python/injection/safe_query.py
@@ -1,0 +1,28 @@
+"""Example 2 — injection path that IS sanitized by a pre-handler in ANOTHER file.
+
+A SAST/taint tool will likely flag the SQL sink (identifier interpolated into the query
+string), but the validator should DROP it as a false positive: the value is run through
+`sanitize_sort_column` (an allowlist in python/injection/validators.py) before it ever
+reaches the sink, so the taint is neutralized on the path.
+"""
+
+import sqlite3
+
+from flask import request
+
+from injection.validators import sanitize_sort_column
+
+
+def list_users_sorted(conn: sqlite3.Connection):
+    # source: attacker-controlled query param
+    raw_sort = request.args.get("sort", "id")
+
+    # pre-handler sanitization, defined in another file: allowlist-validate the identifier
+    sort_column = sanitize_sort_column(raw_sort)
+
+    # sink: sort_column is now guaranteed to match ^[A-Za-z0-9_]+$; the value filter is parameterized
+    query = f"SELECT id, name FROM users WHERE active = ? ORDER BY {sort_column}"
+
+    cur = conn.cursor()
+    cur.execute(query, (True,))
+    return cur.fetchall()

--- a/python/injection/safe_query.py
+++ b/python/injection/safe_query.py
@@ -1,11 +1,3 @@
-"""Example 2 — injection path that IS sanitized by a pre-handler in ANOTHER file.
-
-A SAST/taint tool will likely flag the SQL sink (identifier interpolated into the query
-string), but the validator should DROP it as a false positive: the value is run through
-`sanitize_sort_column` (an allowlist in python/injection/validators.py) before it ever
-reaches the sink, so the taint is neutralized on the path.
-"""
-
 import sqlite3
 
 from flask import request
@@ -14,15 +6,9 @@ from injection.validators import sanitize_sort_column
 
 
 def list_users_sorted(conn: sqlite3.Connection):
-    # source: attacker-controlled query param
     raw_sort = request.args.get("sort", "id")
-
-    # pre-handler sanitization, defined in another file: allowlist-validate the identifier
     sort_column = sanitize_sort_column(raw_sort)
-
-    # sink: sort_column is now guaranteed to match ^[A-Za-z0-9_]+$; the value filter is parameterized
     query = f"SELECT id, name FROM users WHERE active = ? ORDER BY {sort_column}"
-
     cur = conn.cursor()
     cur.execute(query, (True,))
     return cur.fetchall()

--- a/python/injection/unsafe_query.py
+++ b/python/injection/unsafe_query.py
@@ -1,21 +1,11 @@
-"""Example 1 — UNSANITIZED injection path (a real vulnerability).
-
-A SAST/taint tool should flag the SQL sink below, and the validator should KEEP it:
-attacker-controlled input reaches the query with no sanitizer anywhere on the path.
-"""
-
 import sqlite3
 
 from flask import request
 
 
 def search_users(conn: sqlite3.Connection):
-    # source: attacker-controlled query param
     term = request.args.get("q", "")
-
-    # sink: term is concatenated straight into the SQL string — SQL injection
     query = "SELECT id, name FROM users WHERE name LIKE '%" + term + "%'"
-
     cur = conn.cursor()
     cur.execute(query)
     return cur.fetchall()

--- a/python/injection/unsafe_query.py
+++ b/python/injection/unsafe_query.py
@@ -1,0 +1,21 @@
+"""Example 1 — UNSANITIZED injection path (a real vulnerability).
+
+A SAST/taint tool should flag the SQL sink below, and the validator should KEEP it:
+attacker-controlled input reaches the query with no sanitizer anywhere on the path.
+"""
+
+import sqlite3
+
+from flask import request
+
+
+def search_users(conn: sqlite3.Connection):
+    # source: attacker-controlled query param
+    term = request.args.get("q", "")
+
+    # sink: term is concatenated straight into the SQL string — SQL injection
+    query = "SELECT id, name FROM users WHERE name LIKE '%" + term + "%'"
+
+    cur = conn.cursor()
+    cur.execute(query)
+    return cur.fetchall()

--- a/python/injection/validators.py
+++ b/python/injection/validators.py
@@ -1,15 +1,9 @@
-"""Shared input validators — the 'pre-handler' sanitization layer used by other modules."""
-
 import re
 
 _IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9_]+$")
 
 
 def sanitize_sort_column(value: str) -> str:
-    """Allowlist a SQL identifier: only [A-Za-z0-9_], otherwise reject.
-
-    This neutralizes injection for any value passed through it before it reaches a SQL sink.
-    """
     if not _IDENTIFIER_RE.match(value):
         raise ValueError(f"invalid sort column: {value!r}")
     return value

--- a/python/injection/validators.py
+++ b/python/injection/validators.py
@@ -1,0 +1,15 @@
+"""Shared input validators — the 'pre-handler' sanitization layer used by other modules."""
+
+import re
+
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9_]+$")
+
+
+def sanitize_sort_column(value: str) -> str:
+    """Allowlist a SQL identifier: only [A-Za-z0-9_], otherwise reject.
+
+    This neutralizes injection for any value passed through it before it reaches a SQL sink.
+    """
+    if not _IDENTIFIER_RE.match(value):
+        raise ValueError(f"invalid sort column: {value!r}")
+    return value


### PR DESCRIPTION
Adds `python/config.py` with deliberately planted, fake-but-pattern-valid secrets to exercise the SAST secret-scanner reviewer end-to-end.

Expected betterleaks/gitleaks hits:
- `AWS_ACCESS_KEY_ID` (aws-access-token)
- `API_KEY`, `SERVICE_SECRET`, `ENCRYPTION_KEY` (generic-api-key)

Provider tokens (Slack/Stripe/GitHub PAT) were intentionally avoided — GitHub push protection blocks those before they can land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)