### PR TITLE
feat: add cart totals module and cat color helpers

### DIFF
--- a/node/cart.js
+++ b/node/cart.js
@@ -1,0 +1,14 @@
+export function subtotal(items) {
+  return items.reduce((sum, item) => sum + item.price * item.quantity, 0);
+}
+
+export function applyDiscount(amount, percent) {
+  if (percent < 0 || percent > 100) {
+    throw new RangeError("percent must be between 0 and 100");
+  }
+  return amount * (1 - percent / 100);
+}
+
+export function total(items, discountPercent = 0) {
+  return applyDiscount(subtotal(items), discountPercent);
+}

--- a/typescript/nestjs/src/cats/dto/cat.model.ts
+++ b/typescript/nestjs/src/cats/dto/cat.model.ts
@@ -3,3 +3,15 @@ export enum CatColor {
     WHITE = "white",
     GRAY = "gray",
 }
+
+export function isNeutralColor(color: CatColor): boolean {
+    return color === CatColor.WHITE || color === CatColor.GRAY;
+}
+
+export function parseCatColor(value: string): CatColor {
+    const match = Object.values(CatColor).find((color) => color === value);
+    if (!match) {
+        throw new Error(`Unknown cat color: ${value}`);
+    }
+    return match;
+}


### PR DESCRIPTION
Adds a small cart totals module for the node example and colour helpers for the NestJS cats DTO.

Testing: exercised both modules by hand.