### PR TITLE
feat: add string helpers and cats count/findOne endpoints

### DIFF
--- a/python/strings.py
+++ b/python/strings.py
@@ -12,3 +12,7 @@ def truncate(text, limit):
 
 def initials(full_name):
     return "".join(part[0].upper() for part in full_name.split() if part)
+
+
+def title_case(text):
+    return " ".join(word.capitalize() for word in text.split())

--- a/python/strings.py
+++ b/python/strings.py
@@ -1,0 +1,14 @@
+def slugify(text):
+    return "-".join(text.lower().split())
+
+
+def truncate(text, limit):
+    if limit < 0:
+        raise ValueError("limit must be non-negative")
+    if len(text) <= limit:
+        return text
+    return text[:limit].rstrip() + "..."
+
+
+def initials(full_name):
+    return "".join(part[0].upper() for part in full_name.split() if part)

--- a/typescript/nestjs/src/cats/cats.controller.ts
+++ b/typescript/nestjs/src/cats/cats.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Param, Post, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, NotFoundException, Param, Post, UseGuards } from '@nestjs/common';
 import { Roles } from '../common/decorators/roles.decorator';
 import { RolesGuard } from '../common/guards/roles.guard';
 import { ParseIntPipe } from '../common/pipes/parse-int.pipe';
@@ -22,11 +22,22 @@ export class CatsController {
     return this.catsService.findAll();
   }
 
+  @Get('count')
+  async count(): Promise<number> {
+    const cats = await this.catsService.findAll();
+    return cats.length;
+  }
+
   @Get(':id')
-  findOne(
+  async findOne(
     @Param('id', new ParseIntPipe())
     id: number,
-  ) {
-    // get by ID logic
+  ): Promise<Cat> {
+    const cats = await this.catsService.findAll();
+    const cat = cats[id];
+    if (!cat) {
+      throw new NotFoundException(`No cat at index ${id}`);
+    }
+    return cat;
   }
 }


### PR DESCRIPTION
Adds python string helpers (slugify, truncate, initials) and implements the cats count and findOne endpoints.

Testing: manual sanity checks.