### PR TITLE
feat: add python stats helpers and node debounce

### DIFF
--- a/node/debounce.js
+++ b/node/debounce.js
@@ -1,0 +1,7 @@
+export function debounce(fn, waitMs) {
+  let timer;
+  return (...args) => {
+    clearTimeout(timer);
+    timer = setTimeout(() => fn(...args), waitMs);
+  };
+}

--- a/python/stats.py
+++ b/python/stats.py
@@ -1,0 +1,14 @@
+def mean(values):
+    if not values:
+        raise ValueError("values must not be empty")
+    return sum(values) / len(values)
+
+
+def median(values):
+    if not values:
+        raise ValueError("values must not be empty")
+    ordered = sorted(values)
+    mid = len(ordered) // 2
+    if len(ordered) % 2:
+        return ordered[mid]
+    return (ordered[mid - 1] + ordered[mid]) / 2


### PR DESCRIPTION
Adds mean/median helpers in python and a debounce helper for the node example.

Testing: exercised by hand.